### PR TITLE
Add rerun visualization utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ pip install vita-tools[gpu,dev]
 
 ```python
 import numpy as np
-from vita_toolkit import depth_rgb_to_pcd, visualize_point_cloud, points_to_voxel_batch
+from vita_toolkit import (
+    depth_rgb_to_pcd,
+    visualize_point_cloud,
+    visualize_bev,
+    points_to_voxel_batch,
+)
 
 # Convert depth image to point cloud
 depth = np.random.rand(480, 640).astype(np.float32)

--- a/vita_toolkit/point_cloud/viz.py
+++ b/vita_toolkit/point_cloud/viz.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def visualize_point_cloud(
+    points: np.ndarray, colors: np.ndarray | None = None, *, backend: str = "rerun"
+) -> None:
+    """Visualize point cloud using rerun."""
+    if backend != "rerun":
+        raise ValueError("Only rerun backend is supported")
+
+    import rerun as rr
+
+    rr.init("point_cloud", spawn=True)
+
+    points = np.asarray(points, dtype=np.float32)
+    if colors is not None:
+        colors = np.asarray(colors, dtype=np.float32)
+        rr.log("points", rr.Points3D(points, colors=colors))
+    else:
+        rr.log("points", rr.Points3D(points))
+
+
+def visualize_bev(bev_map: np.ndarray, *, backend: str = "rerun") -> None:
+    """Visualize bird's eye view map using rerun."""
+    if backend != "rerun":
+        raise ValueError("Only rerun backend is supported")
+
+    import rerun as rr
+
+    rr.init("bev_map", spawn=True)
+
+    bev_map = np.asarray(bev_map)
+    rr.log("bev", rr.Image(bev_map))

--- a/vita_toolkit/point_cloud/viz.py
+++ b/vita_toolkit/point_cloud/viz.py
@@ -1,17 +1,20 @@
 import numpy as np
 
 
-def visualize_point_cloud(
-    points: np.ndarray, colors: np.ndarray | None = None, *, backend: str = "rerun"
-) -> None:
-    """Visualize point cloud using rerun."""
+def _initialize_rerun(backend: str, init_name: str) -> None:
+    """Initialize the rerun backend."""
     if backend != "rerun":
         raise ValueError("Only rerun backend is supported")
 
     import rerun as rr
+    rr.init(init_name, spawn=True)
 
-    rr.init("point_cloud", spawn=True)
 
+def visualize_point_cloud(
+    points: np.ndarray, colors: np.ndarray | None = None, *, backend: str = "rerun"
+) -> None:
+    """Visualize point cloud using rerun."""
+    _initialize_rerun(backend, "point_cloud")
     points = np.asarray(points, dtype=np.float32)
     if colors is not None:
         colors = np.asarray(colors, dtype=np.float32)


### PR DESCRIPTION
## Summary
- add new point cloud visualization module using rerun
- document importing the new functions in README

## Testing
- `pytest -q`
- `ruff check vita_toolkit/point_cloud/viz.py`
- `ruff format --check vita_toolkit/point_cloud/viz.py`


------
https://chatgpt.com/codex/tasks/task_e_686e243b9ec48333afaca0c09d9168fb