### PR TITLE
Add setup.py for pip install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ uv run ruff format vita_toolkit/
 - Matplotlib
 - SciPy
 - LMDB
+- Rerun SDK
 
 ### GPU Dependencies (optional)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "pillow>=10.0.0",
     "matplotlib>=3.7.0",
     "scipy>=1.10.0",
-    "open3d>=0.17.0"
+    "open3d>=0.17.0",
+    "rerun-sdk>=0.24.0"
 ]
 
 [project.optional-dependencies]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="vita-tools",
+    version="0.1.0",
+    description="Computer vision toolkit for 3D point cloud processing and visualization",
+    author="DylanLi",
+    author_email="dylan.h.li@outlook.com",
+    packages=find_packages(include=["vita_toolkit", "vita_toolkit.*"]),
+    python_requires=">=3.11",
+    install_requires=[
+        "lmdb>=1.6.2",
+        "numpy>=1.24.0",
+        "opencv-python>=4.8.0",
+        "pillow>=10.0.0",
+        "matplotlib>=3.7.0",
+        "scipy>=1.10.0",
+        "open3d>=0.17.0",
+        "rerun-sdk>=0.24.0",
+    ],
+    extras_require={
+        "gpu": [
+            "torch>=2.0.0",
+            "torchvision>=0.15.0",
+            "transformers>=4.30.0",
+            "accelerate>=0.20.0",
+        ],
+        "dev": [
+            "pytest>=7.0.0",
+            "pytest-cov>=4.0.0",
+            "black>=23.0.0",
+            "isort>=5.12.0",
+            "flake8>=6.0.0",
+            "mypy>=1.0.0",
+        ],
+    },
+)


### PR DESCRIPTION
## Summary
- add `setup.py` so `pip install` works on systems expecting classic packaging
- install rerun-sdk by default for visualization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4e9b3db88333b9380b738e712fcf